### PR TITLE
Add line breaks to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,3 @@
-s Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this file,
+You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Correct a typo and add line breaks to the LICENSE.

Let's confirm whether we want to just add the reference to the license like this, or if/how we add the full license, before merging this PR.
